### PR TITLE
Fix problems with base IRIs and IRIs without slashes

### DIFF
--- a/lib/SWObjects.cpp
+++ b/lib/SWObjects.cpp
@@ -176,6 +176,7 @@ HTURI::HTURI (std::string name) : DummyHTURI()
 
     p = after_scheme;
     if (p < name.size() && name[p]=='/'){
+	    absoluteP = true;
 	if (name[p+1]=='/') {
 	    host = name.substr(p+2, name.size());/* host has been specified 	*/
 	    hostP = true;
@@ -184,14 +185,11 @@ HTURI::HTURI (std::string name) : DummyHTURI()
 	    if(p != std::string::npos) {
 	        host.erase(p);			/* Terminate host */
 	        absolute = name.substr(p+1, name.size());/* Root has been found */
-		absoluteP = true;
-	    } else if (fragmentP) {
-		absoluteP = true;
+	    } else {
 		slashlessP = true;
 	    }
 	} else {
 	    absolute = name.substr(p+1, name.size());	/* Root found but no host */
-	    absoluteP = true;
 	}	    
     } else if (after_scheme < name.size()) {
         relative = name.substr(after_scheme, name.size());

--- a/lib/SimpleServer.hpp
+++ b/lib/SimpleServer.hpp
@@ -1525,6 +1525,8 @@ struct SimpleEngine {
 			    IStreamContext& istr,
 			    ResultSet& rs,
 			    RdfDB* db) {
+  // "-" stands for for STDIN/STDOUT; don't treat as IRI
+	if (nameStr == "-") nameStr = "";
 	/**
 	 * Look for a couple of sparql-specific non-standard "media types".
 	 */


### PR DESCRIPTION
This pull requests consists of fixes for two related problems.
### A hyphen is used as base IRI when using STDIN

Given the same file `no-trailing-slash.rdf`:

``` xml
<?xml version="1.0"?>
<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
<rdf:Description rdf:about="a"><a xmlns="a:a#" rdf:resource="https://example.org"/></rdf:Description>
</rdf:RDF>
```

We get the following result:

``` bash
$ cat no-trailing-slash.rdf | sparql -l rdfxml -d -
<?xml version='1.0'?>
<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
<rdf:Description rdf:about='a'><a xmlns='a:a#' rdf:resource='https://example.org-'/></rdf:Description>
</rdf:RDF>
```

Note the incorrect hyphen at the end of the IRI. This is fixed by 06a70d5.
### A URI without trailing slash is not considered absolute

Given the file `no-trailing-slash.rdf`:

``` xml
<?xml version="1.0"?>
<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
<rdf:Description rdf:about="a"><a xmlns="a:a#" rdf:resource="https://example.org"/></rdf:Description>
</rdf:RDF>
```

We get the following result:

``` bash
$ sparql -b https://example.org/foo/bar -l rdfxml -d no-trailing-slash.rdf
<?xml version='1.0'?>
<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
<rdf:Description rdf:about='https://example.org/foo/a'><a xmlns='a:a#' rdf:resource='https://example.org/foo/bar'/></rdf:Description>
</rdf:RDF
```

Note how the IRI has suddenly changed to the base IRI. This is fixed by f193c9d.
### Remarks

While f193c9d has the intended effect, I am not sure whether it is correct in the context of the relative/absolute IRI algorithm. The intentions of the code were rather hard to grasp for me, so I suggest to inspect closely.

Also, the second fix hides the first one with the above example; though other examples can be found.
